### PR TITLE
Add support for using id as the local primary key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-osx_image: xcode7
+osx_image: xcode7.3
 language: objective-c
 cache: cocoapods
 before_install: gem install xcpretty cocoapods obcd slather -N

--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@
 
 ## Usage
 
-By default **NSEntityDescription-SYNCPrimaryKey** gives `id` for remote primary key and `remoteID` for the local primary key.
+By default **NSEntityDescription-SYNCPrimaryKey** gives `id` for remote primary key and `id` for the local primary key. 
 
-You can mark any attribute as primary key by adding `hyper.isPrimaryKey` and the value `YES` and map it to a remote if by adding `hyper.remoteKey` and the value the primary key in your JSON or remote entity such as `contract_id`.
+You can mark any attribute as primary key by adding `hyper.isPrimaryKey` and the value `YES`. You can also map it to any remote JSON attribute by adding `hyper.remoteKey` and the value the primary key in your JSON or remote entity such as `contract_id`.
+
+**NSEntityDescription-SYNCPrimaryKey** will first look for a custom local primary key, then it will look for `id` and finally for `remoteID`, if after this no primary key is found, it will crash and burn.
 
 ![Custom primary key](https://raw.githubusercontent.com/hyperoslo/Sync/master/Images/custom-primary-key-v2.png)
 

--- a/Source/NSEntityDescription+SYNCPrimaryKey.h
+++ b/Source/NSEntityDescription+SYNCPrimaryKey.h
@@ -1,6 +1,7 @@
 @import CoreData;
 
-static NSString * _Nonnull const SYNCDefaultLocalPrimaryKey = @"remoteID";
+static NSString * _Nonnull const SYNCDefaultLocalPrimaryKey = @"id";
+static NSString * _Nonnull const SYNCDefaultLocalCompatiblePrimaryKey = @"remoteID";
 static NSString * _Nonnull const SYNCDefaultRemotePrimaryKey = @"id";
 
 static NSString * _Nonnull const SYNCCustomLocalPrimaryKey = @"hyper.isPrimaryKey";

--- a/Source/NSEntityDescription+SYNCPrimaryKey.m
+++ b/Source/NSEntityDescription+SYNCPrimaryKey.m
@@ -18,7 +18,7 @@
             *stop = YES;
         }
 
-        if ([key isEqualToString:SYNCDefaultLocalPrimaryKey]) {
+        if ([key isEqualToString:SYNCDefaultLocalPrimaryKey] || [key isEqualToString:SYNCDefaultLocalCompatiblePrimaryKey]) {
             primaryKeyAttribute = attributeDescription;
         }
     }];
@@ -38,7 +38,7 @@
     NSString *remoteKey = primaryAttribute.userInfo[SYNCCustomRemoteKey];
 
     if (!remoteKey) {
-        if ([primaryAttribute.name isEqualToString:SYNCDefaultLocalPrimaryKey]) {
+        if ([primaryAttribute.name isEqualToString:SYNCDefaultLocalPrimaryKey] || [primaryAttribute.name isEqualToString:SYNCDefaultLocalCompatiblePrimaryKey]) {
             remoteKey = SYNCDefaultRemotePrimaryKey;
         } else {
             remoteKey = [primaryAttribute.name hyp_remoteString];

--- a/Tests/Pod.xcdatamodeld/Demo.xcdatamodel/contents
+++ b/Tests/Pod.xcdatamodeld/Demo.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="7549" systemVersion="14E7f" minimumToolsVersion="Automatic" macOSVersion="Automatic" iOSVersion="Automatic">
+<model userDefinedModelVersionIdentifier="" type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="10174" systemVersion="15E65" minimumToolsVersion="Automatic">
     <entity name="NoID" syncable="YES">
         <attribute name="attribute" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
@@ -10,6 +10,10 @@
                 <entry key="hyper.isPrimaryKey" value="YES"/>
             </userInfo>
         </attribute>
+    </entity>
+    <entity name="SimpleID" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String" syncable="YES"/>
+        <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
     <entity name="Tag" syncable="YES">
         <attribute name="attribute" optional="YES" attributeType="String" syncable="YES"/>
@@ -29,5 +33,6 @@
         <element name="Note" positionX="-20" positionY="18" width="128" height="75"/>
         <element name="Tag" positionX="160" positionY="0" width="128" height="75"/>
         <element name="User" positionX="-207" positionY="-15" width="128" height="73"/>
+        <element name="SimpleID" positionX="-27" positionY="18" width="128" height="75"/>
     </elements>
 </model>

--- a/Tests/Tests.m
+++ b/Tests/Tests.m
@@ -27,15 +27,23 @@
     XCTAssertEqualObjects(attribute.attributeValueClassName, @"NSNumber");
     XCTAssertEqual(attribute.attributeType, NSInteger32AttributeType);
 
+    entity = [self entityForName:@"SimpleID"];
+    attribute = [entity sync_primaryKeyAttribute];
+    XCTAssertEqualObjects(attribute.attributeValueClassName, @"NSString");
+    XCTAssertEqual(attribute.attributeType, NSStringAttributeType);
+    XCTAssertEqualObjects(attribute.name, @"id");
+
     entity = [self entityForName:@"Note"];
     attribute = [entity sync_primaryKeyAttribute];
     XCTAssertEqualObjects(attribute.attributeValueClassName, @"NSNumber");
     XCTAssertEqual(attribute.attributeType, NSInteger16AttributeType);
+    XCTAssertEqualObjects(attribute.name, @"uniqueID");
 
     entity = [self entityForName:@"Tag"];
     attribute = [entity sync_primaryKeyAttribute];
     XCTAssertEqualObjects(attribute.attributeValueClassName, @"NSString");
     XCTAssertEqual(attribute.attributeType, NSStringAttributeType);
+    XCTAssertEqualObjects(attribute.name, @"randomId");
 
     entity = [self entityForName:@"NoID"];
     attribute = [entity sync_primaryKeyAttribute];
@@ -44,8 +52,10 @@
 
 - (void)testLocalKey {
     NSEntityDescription *entity = [self entityForName:@"User"];
-
     XCTAssertEqualObjects([entity sync_localKey], @"remoteID");
+
+    entity = [self entityForName:@"SimpleID"];
+    XCTAssertEqualObjects([entity sync_localKey], @"id");
 
     entity = [self entityForName:@"Note"];
     XCTAssertEqualObjects([entity sync_localKey], @"uniqueID");
@@ -59,6 +69,9 @@
 
 - (void)testRemoteKey {
     NSEntityDescription *entity = [self entityForName:@"User"];
+    XCTAssertEqualObjects([entity sync_remoteKey], @"id");
+
+    entity = [self entityForName:@"SimpleID"];
     XCTAssertEqualObjects([entity sync_remoteKey], @"id");
 
     entity = [self entityForName:@"Note"];


### PR DESCRIPTION
`id` wasn't considered in the first round because is a reserved word on Objective-C, in Swift it isn't. 💥 

I have kept the old `remoteID` for compatibility reasons, although I'll update everything to mention `id` as the preferred way.
